### PR TITLE
fix: get rid of (most?) memory leaks

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -7,7 +7,7 @@ tasks:
 
   test:
     cmds:
-      - odin test .
+      - odin test . -out:bin/test -o:none -debug
     sources:
       - ./**/*.odin
     aliases:


### PR DESCRIPTION
Should fix #3 

Gets rid of (most?) memory leaks, with tracking allocator reporting no leaks for `Command` union in test. Not that big of an issue if a minor leak exists; you tend to parse CLI arguments at the beginning of a program and that's it. Still, nicer to not leak memory.